### PR TITLE
Fix start scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "lint": "pnpm --filter --if-present lint",
     "lint:fix": "pnpm --filter --if-present lint:fix",
     "start": "concurrently 'pnpm:start:*' --restart-after 5000 --prefix-colors cyan,white,yellow",
-    "start:addon": "pnpm --workspace ember-composable-helpers",
-    "start:test-app": "pnpm filter --workspace start test-app",
+    "start:addon": "pnpm --filter ember-composable-helpers start --no-watch.clearScreen",
+    "start:test-app": "pnpm --filter test-app start",
     "test": "pnpm --workspaces --if-present test"
   },
   "devDependencies": {


### PR DESCRIPTION
Running `pnpm start` seems to return these errors:

```
'ember-composable-helpers' is not recognized as an internal or external command, operable program or batch file.
'filter' is not recognized as an internal or external command, operable program or batch file.
````

Even after reading the pnpm docs I am still unclear on the purpose of the `--workspace` flag, but I have updated the scripts using other V2 addons as reference and it seems to work correctly now.