### PR TITLE
fix: `findBy` return type

### DIFF
--- a/ember-composable-helpers/src/helpers/find-by.ts
+++ b/ember-composable-helpers/src/helpers/find-by.ts
@@ -3,7 +3,7 @@ import { isEmpty } from '@ember/utils';
 import { get } from "@ember/object";
 import asArray from '../utils/as-array.ts';
 
-export function findBy<T>([byPath, value, array]: [keyof T, T[keyof T], T[]]) {
+export function findBy<T>([byPath, value, array]: [keyof T, T[keyof T], T[]]): : T | undefined {
   if (isEmpty(byPath)) {
     return undefined;
   }

--- a/ember-composable-helpers/src/helpers/find-by.ts
+++ b/ember-composable-helpers/src/helpers/find-by.ts
@@ -3,7 +3,7 @@ import { isEmpty } from '@ember/utils';
 import { get } from "@ember/object";
 import asArray from '../utils/as-array.ts';
 
-export function findBy<T>([byPath, value, array]: [keyof T, T[keyof T], T[]]): : T | undefined {
+export function findBy<T>([byPath, value, array]: [keyof T, T[keyof T], T[]]): T | undefined {
   if (isEmpty(byPath)) {
     return undefined;
   }


### PR DESCRIPTION
currently return types is inferred as `never[] | T | undefined` which confuses `glint` and hard to bypass. Perhaps more appropriate is to just enforce `T | undefined`