### PR TITLE
Make "pick" helper types less restrictive

### DIFF
--- a/ember-composable-helpers/src/helpers/pick.ts
+++ b/ember-composable-helpers/src/helpers/pick.ts
@@ -2,9 +2,9 @@ import { helper } from '@ember/component/helper';
 import { get } from '@ember/object';
 import type { AnyVoidFn } from '../utils/types';
 
-export function pick([path, action]: [string, AnyVoidFn]) {
-  return function(event: Event) {
-    let value = get(event, path);
+export function pick<T extends Event | Record<string, unknown>>([path, action]: [string, AnyVoidFn]) {
+  return function(obj: T) {
+    let value = get(obj, path);
 
     if (!action) {
       return value;


### PR DESCRIPTION
In our codebase we frequently use the pick helper with objects that aren't Events (although that is one of the more common use cases). For example we have generic components that fire an action with an object, and we only want one property from the object to be passed up the action chain to more specific components. e.g.:

```
// the object passed into the `onSave` action inside the child component:
{
  foo: { ... }, 
  bar: { ... },
}

// the parent component template:
  <ChildComponent
    @onSave={{pick "foo" @onSave}}
  />
```

This attempts to relax the typing on the pick helper so it will accept either an object (or rather `Record<string, unknown>`) OR an Event.