### PR TITLE
fix: `queue` signature

### DIFF
--- a/ember-composable-helpers/src/helpers/queue.ts
+++ b/ember-composable-helpers/src/helpers/queue.ts
@@ -5,7 +5,10 @@ function invokeMaybeNullable(curr: (...args1: unknown[]) => void | null, args: u
   return curr == null ? undefined : curr(...args);
 }
 
-export function queue(actions: (() => void)[] = []) {
+
+export function queue(positional: unknown[] = []) {
+  const actions = positional as (() => void)[];
+
   return function(...args: unknown[]) {
     let invokeWithArgs = function(acc: unknown, curr: () => void) {
       if (isPromise(acc)) {
@@ -25,4 +28,4 @@ export function queue(actions: (() => void)[] = []) {
   };
 }
 
-export default helper(queue as (actions: unknown[]) => unknown);
+export default helper(queue);


### PR DESCRIPTION
currently `queue` helper yield following signature:

```ts
export declare function queue(actions?: (() => void)[]): (...args: unknown[]) => unknown;
declare const _default: import("@ember/component/helper").FunctionBasedHelper<{
    Args: {
        Positional: unknown[];
        Named: object;
    };
    Return: unknown;
}>;
export default _default;
```
in situations where `queue` helper is invoked from `on` modifier and `Return: unknown;` results in an error:

```
Argument of type 'unknown' is not assignable to parameter of type '(event: MouseEvent) => void'.
```

Perhaps we need to update helper to yield signature like this:

```ts
export declare function queue(positional?: unknown[]): (...args: unknown[]) => unknown;
declare const _default: import("@ember/component/helper").FunctionBasedHelper<{
    Args: {
        Positional: unknown[];
        Named: object;
    };
    Return: (...args: unknown[]) => unknown;
}>;
export default _default;
```

