### PR TITLE
fix: make `byPath` type generic for various array helpers, update `reject-by` signature

### DIFF
--- a/ember-composable-helpers/src/helpers/find-by.ts
+++ b/ember-composable-helpers/src/helpers/find-by.ts
@@ -3,7 +3,11 @@ import { isEmpty } from '@ember/utils';
 import { get } from '@ember/object';
 import asArray from '../utils/as-array.ts';
 
-export function findBy<T, K extends keyof T>([byPath, value, array]: [K, T[K], T[]]) {
+export function findBy<T, K extends keyof T>([byPath, value, array]: [
+  K,
+  T[K],
+  T[],
+]) {
   if (isEmpty(byPath)) {
     return undefined;
   }

--- a/ember-composable-helpers/src/helpers/find-by.ts
+++ b/ember-composable-helpers/src/helpers/find-by.ts
@@ -3,7 +3,7 @@ import { isEmpty } from '@ember/utils';
 import { get } from '@ember/object';
 import asArray from '../utils/as-array.ts';
 
-export function findBy<T>([byPath, value, array]: [keyof T, T[keyof T], T[]]) {
+export function findBy<T, K extends keyof T>([byPath, value, array]: [K, T[K], T[]]) {
   if (isEmpty(byPath)) {
     return undefined;
   }

--- a/ember-composable-helpers/src/helpers/group-by.ts
+++ b/ember-composable-helpers/src/helpers/group-by.ts
@@ -2,7 +2,7 @@ import { helper } from '@ember/component/helper';
 import { get } from '@ember/object';
 import asArray from '../utils/as-array.ts';
 
-export function groupBy<T>([byPath, array]: [string, T[]]) {
+export function groupBy<T, K extends keyof T & string>([byPath, array]: [K, T[]]) {
   const groups: { [key: string]: T[] } = {};
 
   asArray(array).forEach((item) => {

--- a/ember-composable-helpers/src/helpers/group-by.ts
+++ b/ember-composable-helpers/src/helpers/group-by.ts
@@ -2,7 +2,10 @@ import { helper } from '@ember/component/helper';
 import { get } from '@ember/object';
 import asArray from '../utils/as-array.ts';
 
-export function groupBy<T, K extends keyof T & string>([byPath, array]: [K, T[]]) {
+export function groupBy<T, K extends keyof T & string>([byPath, array]: [
+  K,
+  T[],
+]) {
   const groups: { [key: string]: T[] } = {};
 
   asArray(array).forEach((item) => {

--- a/ember-composable-helpers/src/helpers/map-by.ts
+++ b/ember-composable-helpers/src/helpers/map-by.ts
@@ -3,7 +3,7 @@ import { get } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import asArray from '../utils/as-array.ts';
 
-export function mapBy<T extends object>([byPath, array]: [keyof T, T[]]) {
+export function mapBy<T extends object, K extends keyof T>([byPath, array]: [K, T[]]) {
   if (isEmpty(byPath)) {
     return [];
   }

--- a/ember-composable-helpers/src/helpers/map-by.ts
+++ b/ember-composable-helpers/src/helpers/map-by.ts
@@ -3,7 +3,10 @@ import { get } from '@ember/object';
 import { isEmpty } from '@ember/utils';
 import asArray from '../utils/as-array.ts';
 
-export function mapBy<T extends object, K extends keyof T>([byPath, array]: [K, T[]]) {
+export function mapBy<T extends object, K extends keyof T>([byPath, array]: [
+  K,
+  T[],
+]) {
   if (isEmpty(byPath)) {
     return [];
   }

--- a/ember-composable-helpers/src/helpers/reject-by.ts
+++ b/ember-composable-helpers/src/helpers/reject-by.ts
@@ -5,16 +5,16 @@ import { get } from '@ember/object';
 import isEqual from '../utils/is-equal.ts';
 import asArray from '../utils/as-array.ts';
 
-export function rejectBy<T extends object, K extends keyof T>([byPath, value, array]: [
-  K,
-  T | T[] | ((value: T[K]) => boolean) | undefined,
-  T[],
-]) {
+export function rejectBy<T extends object, K extends keyof T>([
+  byPath,
+  value,
+  array,
+]: [K, T | ((value: T[K]) => boolean) | undefined, T[]] | [K, T[]]) {
   if (!isEmberArray(array) && isEmberArray(value)) {
     array = value as T[];
     value = undefined;
   }
-  array = asArray(array);
+  array = asArray(array as T[]);
 
   let filterFn;
 

--- a/ember-composable-helpers/src/helpers/reject-by.ts
+++ b/ember-composable-helpers/src/helpers/reject-by.ts
@@ -5,9 +5,9 @@ import { get } from '@ember/object';
 import isEqual from '../utils/is-equal.ts';
 import asArray from '../utils/as-array.ts';
 
-export function rejectBy<T>([byPath, value, array]: [
-  string,
-  T | T[] | undefined,
+export function rejectBy<T extends object, K extends keyof T>([byPath, value, array]: [
+  K,
+  T | T[] | ((value: T[K]) => boolean) | undefined,
   T[],
 ]) {
   if (!isEmberArray(array) && isEmberArray(value)) {

--- a/test-app/type-tests/map-by-test.ts
+++ b/test-app/type-tests/map-by-test.ts
@@ -1,0 +1,7 @@
+import { mapBy } from '@nullvoxpopuli/ember-composable-helpers/helpers/map-by';
+import { expectTypeOf } from 'expect-type';
+
+expectTypeOf(mapBy(['address', [{ address: 1 }]])).toEqualTypeOf<number[]>();
+
+// @ts-expect-error -- byPath isn't a key of array obj
+expectTypeOf(mapBy(['foo', [{ address: 1 }]]));

--- a/test-app/type-tests/reject-by-test.ts
+++ b/test-app/type-tests/reject-by-test.ts
@@ -1,0 +1,6 @@
+import { rejectBy } from '@nullvoxpopuli/ember-composable-helpers/helpers/reject-by';
+import { expectTypeOf } from 'expect-type';
+
+expectTypeOf(rejectBy(['address', [{ address: 1 }]])).toEqualTypeOf<
+  { address: number }[]
+>();


### PR DESCRIPTION
- Make `byPath` type generic for various array helpers
- Update `reject-by` signature to allow two param invocation
- Fixes #33