### PR TITLE
fix(ember v6+, closure-action): resolve issue with barrel imports (import from '@nullvoxpopuli/ember-composable-helpers')

### DIFF
--- a/ember-composable-helpers/src/-private/closure-action.ts
+++ b/ember-composable-helpers/src/-private/closure-action.ts
@@ -4,11 +4,12 @@ const { __loader } = Ember;
 
 let ClosureActionModule = { ACTION: null };
 
-if ('ember-htmlbars/keywords/closure-action' in __loader.registry) {
+if (__loader && 'ember-htmlbars/keywords/closure-action' in __loader.registry) {
   ClosureActionModule = __loader.require(
     'ember-htmlbars/keywords/closure-action',
   );
 } else if (
+  __loader &&
   'ember-routing-htmlbars/keywords/closure-action' in __loader.registry
 ) {
   ClosureActionModule = __loader.require(

--- a/ember-composable-helpers/src/-private/closure-action.ts
+++ b/ember-composable-helpers/src/-private/closure-action.ts
@@ -1,3 +1,8 @@
+/**
+ * Note that this file *at all* is deprecated in ember-source v6,
+ * and will not work in v7 as this import is being removed in v7.
+ * Do not use closure-action with ember-composable-helpers.
+ */
 import Ember from 'ember';
 
 const { __loader } = Ember;

--- a/ember-composable-helpers/src/index.ts
+++ b/ember-composable-helpers/src/index.ts
@@ -27,7 +27,7 @@ export { default as noop } from './helpers/noop.ts';
 export { default as objectAt } from './helpers/object-at.ts';
 export { default as optional } from './helpers/optional.ts';
 export { default as pick } from './helpers/pick.ts';
-// this is deliberate due to how embroider/vite evaluates everything, this helper uses API that no longer exists in Ember 6.x
+// this is deliberate due to how embroider/vite evaluates everything in a module upon import, the underlying APIs used by this helper longer exist in Ember 6.x
 // export { default as pipeAction } from './helpers/pipe-action.ts';
 export { default as pipe } from './helpers/pipe.ts';
 export { default as previous } from './helpers/previous.ts';

--- a/ember-composable-helpers/src/index.ts
+++ b/ember-composable-helpers/src/index.ts
@@ -41,7 +41,7 @@ export { default as shuffle } from './helpers/shuffle.ts';
 export { default as slice } from './helpers/slice.ts';
 export { default as sortBy } from './helpers/sort-by.ts';
 export { default as take } from './helpers/take.ts';
-// this is deliberate due to how embroider/vite evaluates everything, this helper uses API that no longer exists in Ember 6.x
+// this is deliberate due to how embroider/vite evaluates everything in a module upon import, the underlying APIs used by this helper longer exist in Ember 6.x
 // export { default as toggleAction } from './helpers/toggle-action.ts';
 export { default as toggle } from './helpers/toggle.ts';
 export { default as union } from './helpers/union.ts';

--- a/ember-composable-helpers/src/index.ts
+++ b/ember-composable-helpers/src/index.ts
@@ -27,7 +27,8 @@ export { default as noop } from './helpers/noop.ts';
 export { default as objectAt } from './helpers/object-at.ts';
 export { default as optional } from './helpers/optional.ts';
 export { default as pick } from './helpers/pick.ts';
-export { default as pipeAction } from './helpers/pipe-action.ts';
+// this is deliberate due to how embroider/vite evaluates everything, this helper uses API that no longer exists in Ember 6.x
+// export { default as pipeAction } from './helpers/pipe-action.ts';
 export { default as pipe } from './helpers/pipe.ts';
 export { default as previous } from './helpers/previous.ts';
 export { default as queue } from './helpers/queue.ts';
@@ -40,7 +41,8 @@ export { default as shuffle } from './helpers/shuffle.ts';
 export { default as slice } from './helpers/slice.ts';
 export { default as sortBy } from './helpers/sort-by.ts';
 export { default as take } from './helpers/take.ts';
-export { default as toggleAction } from './helpers/toggle-action.ts';
+// this is deliberate due to how embroider/vite evaluates everything, this helper uses API that no longer exists in Ember 6.x
+// export { default as toggleAction } from './helpers/toggle-action.ts';
 export { default as toggle } from './helpers/toggle.ts';
 export { default as union } from './helpers/union.ts';
 export { default as values } from './helpers/values.ts';


### PR DESCRIPTION
fixes: #51 

* make usage ember barrel imports a bit more safe
* and since this imports are no longer available in ember 6.x we remove them from addon barrel reexport to prevent vite failing while eagerly evaluating all imported files if consumers use something like `import { pick } from '@nullvoxpopuli/ember-composable-helpers';` which would evaluete `pipeAction` & `toggleAction` and fail