### PR TITLE
[ note for ember-source < 4.5 ] Remove ember-functions-as-helper-polyfill from the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ To install:
 npm add @nullvoxpopuli/ember-composable-helpers
 ```
 
+If you're using ember-source < 4.5, you may need a [polyfill](https://github.com/ember-polyfills/ember-functions-as-helper-polyfill).
+
+
 To use in an existing project, to replace the original [ember-composable-helpers](https://github.com/DockYard/ember-composable-helpers):
 
 under webpack, configure an alias:

--- a/ember-composable-helpers/package.json
+++ b/ember-composable-helpers/package.json
@@ -63,8 +63,7 @@
   },
   "dependencies": {
     "@embroider/addon-shim": "^1.9.0",
-    "decorator-transforms": "^2.3.0",
-    "ember-functions-as-helper-polyfill": "^2.1.2"
+    "decorator-transforms": "^2.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       decorator-transforms:
         specifier: ^2.3.0
         version: 2.3.0(@babel/core@7.26.9)
-      ember-functions-as-helper-polyfill:
-        specifier: ^2.1.2
-        version: 2.1.2(ember-source@5.8.0(@babel/core@7.26.9)(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0))
     devDependencies:
       '@babel/core':
         specifier: ^7.26.9
@@ -305,7 +302,7 @@ importers:
         version: 1.1.2(@babel/core@7.26.9)
       '@nullvoxpopuli/ember-composable-helpers':
         specifier: workspace:*
-        version: file:ember-composable-helpers(@babel/core@7.26.9)(ember-source@3.28.12(@babel/core@7.26.9))
+        version: link:../ember-composable-helpers
       babel-eslint:
         specifier: ^10.0.3
         version: 10.1.0(eslint@5.16.0)
@@ -428,7 +425,7 @@ importers:
         version: 1.1.2(@babel/core@7.26.9)
       '@nullvoxpopuli/ember-composable-helpers':
         specifier: workspace:*
-        version: file:ember-composable-helpers(@babel/core@7.26.9)(ember-source@3.28.12(@babel/core@7.26.9))
+        version: link:../ember-composable-helpers
       babel-eslint:
         specifier: ^10.0.3
         version: 10.1.0(eslint@5.16.0)
@@ -1614,9 +1611,6 @@ packages:
   '@npmcli/promise-spawn@8.0.2':
     resolution: {integrity: sha512-/bNJhjc+o6qL+Dwz/bqfTQClkEO5nTQ1ZEcdCkAQjhkZMHIh22LPG7fNh1enJP1NKWDqYiiABnjFCY7E0zHYtQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
-
-  '@nullvoxpopuli/ember-composable-helpers@file:ember-composable-helpers':
-    resolution: {directory: ember-composable-helpers, type: directory}
 
   '@octokit/auth-token@5.1.2':
     resolution: {integrity: sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==}
@@ -4123,10 +4117,6 @@ packages:
     resolution: {integrity: sha512-lo5YArbJzJi5ssvaGqTt6+FnhTALnSvYVuxM7lfyL1UCMudyNJ94ovH5C7n5il7ATd6WsNiAPRUO/v+s5Jq/aA==}
     engines: {node: 8.* || >= 10.*}
 
-  ember-cli-typescript@5.3.0:
-    resolution: {integrity: sha512-gFA+ZwmsvvFwo2Jz/B9GMduEn+fPoGb69qWGP0Tp3+Tu5xypDtIKVSZ5086I3Cr19cLXD4HkrOR3YQvdUKzAkQ==}
-    engines: {node: '>= 12.*'}
-
   ember-cli-version-checker@2.2.0:
     resolution: {integrity: sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==}
     engines: {node: '>= 4'}
@@ -4182,12 +4172,6 @@ packages:
   ember-export-application-global@2.0.1:
     resolution: {integrity: sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==}
     engines: {node: '>= 4'}
-
-  ember-functions-as-helper-polyfill@2.1.2:
-    resolution: {integrity: sha512-yvW6xykvZEIYzzwlrC/g9yu6LtLkkj5F+ho6U+BDxN1uREMgoMOZnji7sSILn5ITVpaJ055DPcO+utEFD7IZOA==}
-    engines: {node: '>= 14.0.0'}
-    peerDependencies:
-      ember-source: ^3.25.0 || >=4.0.0
 
   ember-load-initializers@3.0.1:
     resolution: {integrity: sha512-qV3vxJKw5+7TVDdtdLPy8PhVsh58MlK8jwzqh5xeOwJPNP7o0+BlhvwoIlLYTPzGaHdfjEIFCgVSyMRGd74E1g==}
@@ -10560,16 +10544,6 @@ snapshots:
     dependencies:
       which: 5.0.0
 
-  '@nullvoxpopuli/ember-composable-helpers@file:ember-composable-helpers(@babel/core@7.26.9)(ember-source@3.28.12(@babel/core@7.26.9))':
-    dependencies:
-      '@embroider/addon-shim': 1.9.0
-      decorator-transforms: 2.3.0(@babel/core@7.26.9)
-      ember-functions-as-helper-polyfill: 2.1.2(ember-source@3.28.12(@babel/core@7.26.9))
-    transitivePeerDependencies:
-      - '@babel/core'
-      - ember-source
-      - supports-color
-
   '@octokit/auth-token@5.1.2': {}
 
   '@octokit/core@6.1.4':
@@ -14021,21 +13995,6 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-cli-typescript@5.3.0:
-    dependencies:
-      ansi-to-html: 0.6.15
-      broccoli-stew: 3.0.0
-      debug: 4.4.0(supports-color@8.1.1)
-      execa: 4.1.0
-      fs-extra: 9.1.0
-      resolve: 1.22.10
-      rsvp: 4.8.5
-      semver: 7.7.1
-      stagehand: 1.0.1
-      walk-sync: 2.2.0
-    transitivePeerDependencies:
-      - supports-color
-
   ember-cli-version-checker@2.2.0:
     dependencies:
       resolve: 1.22.10
@@ -14401,24 +14360,6 @@ snapshots:
       - eslint
 
   ember-export-application-global@2.0.1: {}
-
-  ember-functions-as-helper-polyfill@2.1.2(ember-source@3.28.12(@babel/core@7.26.9)):
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-typescript: 5.3.0
-      ember-cli-version-checker: 5.1.2
-      ember-source: 3.28.12(@babel/core@7.26.9)
-    transitivePeerDependencies:
-      - supports-color
-
-  ember-functions-as-helper-polyfill@2.1.2(ember-source@5.8.0(@babel/core@7.26.9)(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0)):
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-cli-typescript: 5.3.0
-      ember-cli-version-checker: 5.1.2
-      ember-source: 5.8.0(@babel/core@7.26.9)(@glimmer/component@1.1.2(@babel/core@7.26.9))(@glint/template@1.5.2)(rsvp@4.8.5)(webpack@5.98.0)
-    transitivePeerDependencies:
-      - supports-color
 
   ember-load-initializers@3.0.1(ember-source@3.28.12(@babel/core@7.26.9)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,9 @@ importers:
       ember-export-application-global:
         specifier: ^2.0.0
         version: 2.0.1
+      ember-functions-as-helper-polyfill:
+        specifier: 2.1.3
+        version: 2.1.3(ember-source@3.28.12(@babel/core@7.26.9))
       ember-load-initializers:
         specifier: ^3.0.1
         version: 3.0.1(ember-source@3.28.12(@babel/core@7.26.9))
@@ -471,6 +474,9 @@ importers:
       ember-export-application-global:
         specifier: ^2.0.0
         version: 2.0.1
+      ember-functions-as-helper-polyfill:
+        specifier: 2.1.3
+        version: 2.1.3(ember-source@3.28.12(@babel/core@7.26.9))
       ember-load-initializers:
         specifier: ^3.0.1
         version: 3.0.1(ember-source@3.28.12(@babel/core@7.26.9))
@@ -4117,6 +4123,10 @@ packages:
     resolution: {integrity: sha512-lo5YArbJzJi5ssvaGqTt6+FnhTALnSvYVuxM7lfyL1UCMudyNJ94ovH5C7n5il7ATd6WsNiAPRUO/v+s5Jq/aA==}
     engines: {node: 8.* || >= 10.*}
 
+  ember-cli-typescript@5.3.0:
+    resolution: {integrity: sha512-gFA+ZwmsvvFwo2Jz/B9GMduEn+fPoGb69qWGP0Tp3+Tu5xypDtIKVSZ5086I3Cr19cLXD4HkrOR3YQvdUKzAkQ==}
+    engines: {node: '>= 12.*'}
+
   ember-cli-version-checker@2.2.0:
     resolution: {integrity: sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==}
     engines: {node: '>= 4'}
@@ -4172,6 +4182,12 @@ packages:
   ember-export-application-global@2.0.1:
     resolution: {integrity: sha512-B7wiurPgsxsSGzJuPFkpBWnaeuCu2PGpG2BjyrfA1VcL7//o+5RSnZqiCEY326y7qmxb2GoCgo0ft03KBU0rRw==}
     engines: {node: '>= 4'}
+
+  ember-functions-as-helper-polyfill@2.1.3:
+    resolution: {integrity: sha512-Hte8jfOmSNzrz/vOchf68CGaBWXN2/5qKgFaylqr9omW2i4Wt9JmaBWRkeR0AJ53N57q3DX2TOb166Taq6QjiA==}
+    engines: {node: '>= 14.0.0'}
+    peerDependencies:
+      ember-source: ^3.25.0 || >=4.0.0
 
   ember-load-initializers@3.0.1:
     resolution: {integrity: sha512-qV3vxJKw5+7TVDdtdLPy8PhVsh58MlK8jwzqh5xeOwJPNP7o0+BlhvwoIlLYTPzGaHdfjEIFCgVSyMRGd74E1g==}
@@ -13995,6 +14011,21 @@ snapshots:
       - '@babel/core'
       - supports-color
 
+  ember-cli-typescript@5.3.0:
+    dependencies:
+      ansi-to-html: 0.6.15
+      broccoli-stew: 3.0.0
+      debug: 4.4.0(supports-color@8.1.1)
+      execa: 4.1.0
+      fs-extra: 9.1.0
+      resolve: 1.22.10
+      rsvp: 4.8.5
+      semver: 7.7.1
+      stagehand: 1.0.1
+      walk-sync: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
+
   ember-cli-version-checker@2.2.0:
     dependencies:
       resolve: 1.22.10
@@ -14360,6 +14391,15 @@ snapshots:
       - eslint
 
   ember-export-application-global@2.0.1: {}
+
+  ember-functions-as-helper-polyfill@2.1.3(ember-source@3.28.12(@babel/core@7.26.9)):
+    dependencies:
+      ember-cli-babel: 7.26.11
+      ember-cli-typescript: 5.3.0
+      ember-cli-version-checker: 5.1.2
+      ember-source: 3.28.12(@babel/core@7.26.9)
+    transitivePeerDependencies:
+      - supports-color
 
   ember-load-initializers@3.0.1(ember-source@3.28.12(@babel/core@7.26.9)):
     dependencies:

--- a/test-app-min-supported-classic/config/ember-try.js
+++ b/test-app-min-supported-classic/config/ember-try.js
@@ -14,6 +14,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~3.28.0',
+            'ember-functions-as-helper-polyfill': '^2.1.3',
           },
         },
       },
@@ -22,6 +23,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~4.4.0',
+            'ember-functions-as-helper-polyfill': '^2.1.3',
           },
         },
       },

--- a/test-app-min-supported-classic/package.json
+++ b/test-app-min-supported-classic/package.json
@@ -30,6 +30,7 @@
     "@embroider/core": "^3.5.0",
     "@embroider/webpack": "^4.0.9",
     "@glimmer/component": "^1.1.2",
+    "ember-functions-as-helper-polyfill": "2.1.3",
     "@nullvoxpopuli/ember-composable-helpers": "workspace:*",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",

--- a/test-app-min-supported/config/ember-try.js
+++ b/test-app-min-supported/config/ember-try.js
@@ -14,6 +14,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~3.28.0',
+            'ember-functions-as-helper-polyfill': '^2.1.3',
           },
         },
       },
@@ -22,6 +23,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~4.4.0',
+            'ember-functions-as-helper-polyfill': '^2.1.3',
           },
         },
       },

--- a/test-app-min-supported/package.json
+++ b/test-app-min-supported/package.json
@@ -30,6 +30,7 @@
     "@embroider/core": "^3.5.0",
     "@embroider/webpack": "^4.0.9",
     "@glimmer/component": "^1.1.2",
+    "ember-functions-as-helper-polyfill": "2.1.3",
     "@nullvoxpopuli/ember-composable-helpers": "workspace:*",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -14,6 +14,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~3.28.0',
+            'ember-functions-as-helper-polyfill': '^2.1.3',
           },
         },
       },
@@ -22,6 +23,7 @@ module.exports = async function () {
         npm: {
           devDependencies: {
             'ember-source': '~4.4.0',
+            'ember-functions-as-helper-polyfill': '^2.1.3',
           },
         },
       },


### PR DESCRIPTION
Where this wouldn't be breaking is if you already had ember-functions-as-helper-polyfill in your project.

It may even be enough for some other addon to provide it.

> [!IMPORTANT]
> This is _non-breaking_ for ember-source 4.5 and newer


> [!NOTE]
> Marked as "enhancement" as that's the biggest indicator I can specify without crossing a major version boundary ( i.e.: `0.( + 1 ).0` )