### PR TITLE
Guard against undefined registry in Embroider/Vite

### DIFF
--- a/ember-composable-helpers/src/-private/closure-action.ts
+++ b/ember-composable-helpers/src/-private/closure-action.ts
@@ -9,7 +9,10 @@ const { __loader } = Ember;
 
 let ClosureActionModule = { ACTION: null };
 
-if (__loader?.registry && 'ember-htmlbars/keywords/closure-action' in __loader.registry) {
+if (
+  __loader?.registry &&
+  'ember-htmlbars/keywords/closure-action' in __loader.registry
+) {
   ClosureActionModule = __loader.require(
     'ember-htmlbars/keywords/closure-action',
   );

--- a/ember-composable-helpers/src/-private/closure-action.ts
+++ b/ember-composable-helpers/src/-private/closure-action.ts
@@ -9,12 +9,12 @@ const { __loader } = Ember;
 
 let ClosureActionModule = { ACTION: null };
 
-if (__loader && 'ember-htmlbars/keywords/closure-action' in __loader.registry) {
+if (__loader?.registry && 'ember-htmlbars/keywords/closure-action' in __loader.registry) {
   ClosureActionModule = __loader.require(
     'ember-htmlbars/keywords/closure-action',
   );
 } else if (
-  __loader &&
+  __loader?.registry &&
   'ember-routing-htmlbars/keywords/closure-action' in __loader.registry
 ) {
   ClosureActionModule = __loader.require(


### PR DESCRIPTION
I'm converting an Ember 3.28 app from broccoli to Embroider/Vite. Currently the app is crashing with `Uncaught TypeError: right-hand side of 'in' should be an object, got undefined` on [this line](https://github.com/NullVoxPopuli/ember-composable-helpers/blob/6a0564406e3aec34a7f5f1c5b7bfda549d9a0cba/ember-composable-helpers/src/-private/closure-action.ts#L12). Apparently `__loader` is defined but `__loader.registry` is returning undefined.

The PR guards against this case to prevent the TypeError. I do not know whether it breaks anything else.